### PR TITLE
[Chore] 화면 네비게이션 설정

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,106 +1,14 @@
 import React from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import RootStackNavigator from '../ppu-frontend/src/navigators/RootStackNavigator';
 import { NavigationContainer } from '@react-navigation/native';
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { StyleSheet } from 'react-native';
-import BottomTabBar from './src/components/BottomTabBar';
-import HomeScreen from './src/screens/HomeScreen';
-import OppuScreen from './src/screens/OppuScreen';
-import AddScreen from './src/screens/AddScreen';
-import ArchiveScreen from './src/screens/ArchiveScreen';
-import MyScreen from './src/screens/MyScreen';
-import CreateReviewScreen from './src/screens/CreateReviewScreen';
-
-const Tab = createBottomTabNavigator();
-
-const HomeStack = createNativeStackNavigator();
-const OppuStack = createNativeStackNavigator();
-const AddStack = createNativeStackNavigator();
-const ArchiveStack = createNativeStackNavigator();
-const MyStack = createNativeStackNavigator();
-
-function HomeStackNavigator() {
-  return (
-    <HomeStack.Navigator>
-      <HomeStack.Screen name="HOME" component={HomeScreen} />
-      {/* 필요 시 하위 화면 추가 */}
-    </HomeStack.Navigator>
-  );
-}
-
-function OppuStackNavigator() {
-  return (
-    <OppuStack.Navigator>
-      <OppuStack.Screen
-        name="OPPU"
-        component={OppuScreen}
-        options={{ headerShown: false }}
-      />
-      {/* 필요 시 하위 화면 추가 */}
-    </OppuStack.Navigator>
-  );
-}
-
-function AddStackNavigator() {
-  return (
-    <AddStack.Navigator>
-      <AddStack.Screen name="ADD" component={AddScreen} />
-      {/* 필요 시 하위 화면 추가 */}
-    </AddStack.Navigator>
-  );
-}
-
-function ArchiveStackNavigator() {
-  return (
-    <ArchiveStack.Navigator>
-      <ArchiveStack.Screen
-        name="ARCHIVE"
-        component={ArchiveScreen}
-        options={{ headerShown: false }}
-      />
-      {/* 👇 예시: 시향기 작성 화면을 푸시로 띄우기 */}
-      <ArchiveStack.Screen
-        name="CREATEREVIEW"
-        component={CreateReviewScreen}
-        options={{ title: '시향기 작성' }}
-      />
-    </ArchiveStack.Navigator>
-  );
-}
-
-function MyStackNavigator() {
-  return (
-    <MyStack.Navigator>
-      <MyStack.Screen
-        name="MY"
-        component={MyScreen}
-        options={{ headerShown: false }}
-      />
-      {/* 필요 시 하위 화면 추가 */}
-    </MyStack.Navigator>
-  );
-}
 
 function App() {
   return (
     <SafeAreaView style={styles.container}>
       <NavigationContainer>
-        <Tab.Navigator tabBar={props => <BottomTabBar {...props} />}>
-          <Tab.Screen name="HOMESTACK" component={HomeStackNavigator} />
-          <Tab.Screen
-            name="OPPUSTACK"
-            component={OppuScreen}
-            options={{ headerShown: false }}
-          />
-          <Tab.Screen name="ADDSTACK" component={AddStackNavigator} />
-          <Tab.Screen
-            name="ARCHIVESTACK"
-            component={ArchiveStackNavigator}
-            options={{ headerShown: false }}
-          />
-          <Tab.Screen name="MYSTACK" component={MyStackNavigator} />
-        </Tab.Navigator>
+        <RootStackNavigator />
       </NavigationContainer>
     </SafeAreaView>
   );

--- a/src/components/BottomTabBar/index.tsx
+++ b/src/components/BottomTabBar/index.tsx
@@ -20,7 +20,7 @@ const BottomTabBar: React.FC<BottomTabBarProps> = ({ state, navigation }) => {
       {/* 홈 탭 */}
       <TouchableOpacity
         style={styles.tab}
-        onPress={() => navigation.navigate('HOMESTACK')}
+        onPress={() => navigation.navigate('HomeStack')}
         accessibilityRole="button"
       >
         {state.index === 0 ? (
@@ -39,7 +39,7 @@ const BottomTabBar: React.FC<BottomTabBarProps> = ({ state, navigation }) => {
       {/* 오뿌 탭 */}
       <TouchableOpacity
         style={styles.tab}
-        onPress={() => navigation.navigate('OPPUSTACK')}
+        onPress={() => navigation.navigate('OppuStack')}
         accessibilityRole="button"
       >
         {state.index === 1 ? (
@@ -58,7 +58,7 @@ const BottomTabBar: React.FC<BottomTabBarProps> = ({ state, navigation }) => {
       {/* Add 탭 */}
       <TouchableOpacity
         style={styles.tab}
-        onPress={() => navigation.navigate('ADDSTACK')}
+        onPress={() => navigation.navigate('AddStack')}
         accessibilityRole="button"
         activeOpacity={0.8}
       >
@@ -70,7 +70,7 @@ const BottomTabBar: React.FC<BottomTabBarProps> = ({ state, navigation }) => {
       {/* 시향 탭 */}
       <TouchableOpacity
         style={styles.tab}
-        onPress={() => navigation.navigate('ARCHIVESTACK')}
+        onPress={() => navigation.navigate('ArchiveStack')}
         accessibilityRole="button"
       >
         {state.index === 3 ? (
@@ -89,7 +89,7 @@ const BottomTabBar: React.FC<BottomTabBarProps> = ({ state, navigation }) => {
       {/* 마이 탭 */}
       <TouchableOpacity
         style={styles.tab}
-        onPress={() => navigation.navigate('MYSTACK')}
+        onPress={() => navigation.navigate('MyStack')}
         accessibilityRole="button"
       >
         {state.index === 4 ? (

--- a/src/components/BottomTabBar/styles.ts
+++ b/src/components/BottomTabBar/styles.ts
@@ -3,6 +3,7 @@ import colors from '../../theme/color';
 
 const styles = StyleSheet.create({
   container: {
+    backgroundColor: colors.white,
     flexDirection: 'row',
     paddingVertical: 12,
     paddingHorizontal: 16,

--- a/src/navigators/MainTabNavigator.tsx
+++ b/src/navigators/MainTabNavigator.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import BottomTabBar from '../components/BottomTabBar';
+import AddScreen from '../screens/AddScreen';
+import ArchiveScreen from '../screens/ArchiveScreen';
+import HomeScreen from '../screens/HomeScreen';
+import MyScreen from '../screens/MyScreen';
+import OppuScreen from '../screens/OppuScreen';
+import {
+  HomeStackParamList,
+  OppuStackParamList,
+  AddStackParamList,
+  ArchiveStackParamList,
+  MyStackParamList,
+} from '../types/navigationTypes';
+
+const Tab = createBottomTabNavigator();
+
+const HomeStack = createNativeStackNavigator<HomeStackParamList>();
+const OppuStack = createNativeStackNavigator<OppuStackParamList>();
+const AddStack = createNativeStackNavigator<AddStackParamList>();
+const ArchiveStack = createNativeStackNavigator<ArchiveStackParamList>();
+const MyStack = createNativeStackNavigator<MyStackParamList>();
+
+function HomeStackNavigator() {
+  return (
+    <HomeStack.Navigator screenOptions={{ headerShown: false }}>
+      <HomeStack.Screen name="Home" component={HomeScreen} />
+    </HomeStack.Navigator>
+  );
+}
+
+function OppuStackNavigator() {
+  return (
+    <OppuStack.Navigator screenOptions={{ headerShown: false }}>
+      <OppuStack.Screen name="Oppu" component={OppuScreen} />
+    </OppuStack.Navigator>
+  );
+}
+
+function AddStackNavigator() {
+  return (
+    <AddStack.Navigator screenOptions={{ headerShown: false }}>
+      <AddStack.Screen name="Add" component={AddScreen} />
+      {/* 필요 시 하위 화면 추가 */}
+    </AddStack.Navigator>
+  );
+}
+
+function ArchiveStackNavigator() {
+  return (
+    <ArchiveStack.Navigator screenOptions={{ headerShown: false }}>
+      <ArchiveStack.Screen name="Archive" component={ArchiveScreen} />
+    </ArchiveStack.Navigator>
+  );
+}
+
+function MyStackNavigator() {
+  return (
+    <MyStack.Navigator screenOptions={{ headerShown: false }}>
+      <MyStack.Screen name="My" component={MyScreen} />
+      {/* 필요 시 하위 화면 추가 */}
+    </MyStack.Navigator>
+  );
+}
+
+const MainTabNavigator = () => {
+  return (
+    <Tab.Navigator
+      tabBar={props => <BottomTabBar {...props} />}
+      screenOptions={{ headerShown: false }}
+    >
+      <Tab.Screen name="HomeStack" component={HomeStackNavigator} />
+      <Tab.Screen name="OppuStack" component={OppuStackNavigator} />
+      <Tab.Screen name="AddStack" component={AddStackNavigator} />
+      <Tab.Screen name="ArchiveStack" component={ArchiveStackNavigator} />
+      <Tab.Screen name="MyStack" component={MyStackNavigator} />
+    </Tab.Navigator>
+  );
+};
+
+export default MainTabNavigator;

--- a/src/navigators/RootStackNavigator.tsx
+++ b/src/navigators/RootStackNavigator.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import MainTabNavigator from './MainTabNavigator';
+import CreateReviewScreen from '../screens/CreateReviewScreen';
+import { RootStackParamList } from '../types/navigationTypes';
+
+const RootStack = createNativeStackNavigator<RootStackParamList>();
+
+const RootStackNavigator = () => {
+  return (
+    <RootStack.Navigator screenOptions={{ headerShown: false }}>
+      <RootStack.Screen name="Main" component={MainTabNavigator} />
+      {/* <RootStack.Screen name="CreateOppu" component={OppuWriteScreen} /> */}
+      <RootStack.Screen name="CreateReview" component={CreateReviewScreen} />
+    </RootStack.Navigator>
+  );
+};
+
+export default RootStackNavigator;

--- a/src/screens/ArchiveScreen/index.tsx
+++ b/src/screens/ArchiveScreen/index.tsx
@@ -8,10 +8,15 @@ import CreateReviewButton from '../../components/CreateReviewButton';
 import Gradient from '../../components/Gradient';
 import ReviewFlatList from './components/ReviewFlatList';
 import { useNavigation } from '@react-navigation/native';
+import { RootNavProp } from '../../types/navigationProps';
 
 const ArchiveScreen: React.FC = () => {
-  const navigation = useNavigation();
   const [perfumeReviewList, setPerfumeReviewList] = useState<any[]>([]);
+  const navigation = useNavigation<RootNavProp>();
+
+  const NavigateToCreateReview = () => {
+    navigation.navigate('CreateReview');
+  };
 
   return (
     <SafeAreaView style={styles.safeAreaViewContainer}>
@@ -37,7 +42,7 @@ const ArchiveScreen: React.FC = () => {
               textColor={colors.white}
               label="시향기 작성하기"
               disabled={false}
-              onPress={() => navigation.navigate('CREATEREVIEW' as never)}
+              onPress={NavigateToCreateReview}
             ></CreateReviewButton>
           </View>
         ) : (

--- a/src/types/navigationProps.ts
+++ b/src/types/navigationProps.ts
@@ -1,0 +1,4 @@
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RootStackParamList } from './navigationTypes';
+
+export type RootNavProp = NativeStackNavigationProp<RootStackParamList>;

--- a/src/types/navigationTypes.ts
+++ b/src/types/navigationTypes.ts
@@ -1,0 +1,32 @@
+export type RootStackParamList = {
+  Main: undefined;
+  CreateOppu: undefined;
+  CreateReview: undefined;
+};
+
+/* 추후 로그인 도입 시
+export type AuthStackParamList = {
+  Login: undefined;
+  SignUp: undefined;
+};
+*/
+
+export type HomeStackParamList = {
+  Home: undefined;
+};
+
+export type OppuStackParamList = {
+  Oppu: undefined;
+};
+
+export type AddStackParamList = {
+  Add: undefined;
+};
+
+export type ArchiveStackParamList = {
+  Archive: undefined;
+};
+
+export type MyStackParamList = {
+  My: undefined;
+};


### PR DESCRIPTION
## 👩🏻‍💻 작업 내용
- 네비게이터 코드 분리
- RootStack 에서 크게 하단 탭 관련된 화면들 / 전체 화면들로 구분해서 사용
- [관련 자료 참고](https://reactnavigation.org/docs/hiding-tabbar-in-screens/?config=static)
```
NavigationContainer
 ├─ AuthStack (Login / SignUp) // 나중에 로그인 기능 추가 시
 └─ RootStack
      ├─ 메인 화면 (TabNavigator)
      │    ├─ HomeStack
      │    ├─ OppuStack
      │    ├─ AddStack
      │    └─ MyStack
      ├─ 오뿌 작성 (FullScreen)
      └─ 시향기 작성 (FullScreen)

```

## 👀 PR 포인트

- 이전 시향기 목록 -> 시향기 작성 코드 부분 수정해놨어용
- 탭 있는 화면 -> 전체 화면으로 이동 시 RootStack 사용
```js
// 1️⃣ RootStack 기준으로 navigation 타입 지정
// RootStackParamList에 정의된 스크린 이름만 navigate 가능
const navigation = useNavigation<RootNavProp>();
```

## Next Feature

- #4 
