### PR TITLE
[FEAT/UI] 태그 설정 화면 

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,14 +3,17 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import RootStackNavigator from '../ppu-frontend/src/navigators/RootStackNavigator';
 import { NavigationContainer } from '@react-navigation/native';
 import { StyleSheet } from 'react-native';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 function App() {
   return (
-    <SafeAreaView style={styles.container}>
-      <NavigationContainer>
-        <RootStackNavigator />
-      </NavigationContainer>
-    </SafeAreaView>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <SafeAreaView style={styles.container}>
+        <NavigationContainer>
+          <RootStackNavigator />
+        </NavigationContainer>
+      </SafeAreaView>
+    </GestureHandlerRootView>
   );
 }
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   presets: ['module:@react-native/babel-preset'],
+  plugins: ['react-native-reanimated/plugin'],
 };

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -20,7 +20,8 @@ target 'ppu_frontend' do
   use_react_native!(
     :path => config[:reactNativePath],
     # An absolute path to your application root.
-    :app_path => "#{Pod::Config.instance.installation_root}/.."
+    :app_path => "#{Pod::Config.instance.installation_root}/..",
+    :hermes_enabled => true
   )
 
   post_install do |installer|

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ppu_frontend",
       "version": "0.0.1",
       "dependencies": {
+        "@gorhom/bottom-sheet": "^5.2.4",
         "@react-native-community/blur": "^4.4.1",
         "@react-native/new-app-screen": "0.80.0",
         "@react-navigation/bottom-tabs": "^7.4.2",
@@ -15,9 +16,11 @@
         "@react-navigation/native-stack": "^7.3.25",
         "react": "19.1.0",
         "react-native": "0.80.0",
+        "react-native-gesture-handler": "^2.28.0",
         "react-native-image-crop-picker": "^0.50.1",
         "react-native-linear-gradient": "^2.8.3",
         "react-native-pager-view": "^6.9.1",
+        "react-native-reanimated": "^3.19.1",
         "react-native-safe-area-context": "^5.5.2",
         "react-native-screens": "^4.13.1",
         "react-native-svg": "^15.12.1",
@@ -148,7 +151,6 @@
       "version": "7.27.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
       "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.27.3"
       },
@@ -175,7 +177,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.1.tgz",
       "integrity": "sha512-QwGAmuvM17btKU5VqXfb+Giw4JcN0hjuufz3DYnpeVDvZLAObloM77bhMXiqry3Iio+Ai4phVRDwl6WU10+r5A==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.1",
         "@babel/helper-member-expression-to-functions": "^7.27.1",
@@ -196,7 +197,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.27.1.tgz",
       "integrity": "sha512-uVDC72XVf8UbrH5qQTc18Agb8emwjTiZrQE11Nv3CuBEZmVvTwwE9CBUEvHku06gQCAyYf8Nv6ja1IN+6LMbxQ==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.1",
         "regexpu-core": "^6.2.0",
@@ -229,7 +229,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz",
       "integrity": "sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==",
-      "dev": true,
       "dependencies": {
         "@babel/traverse": "^7.27.1",
         "@babel/types": "^7.27.1"
@@ -270,7 +269,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
       "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.27.1"
       },
@@ -307,7 +305,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
       "integrity": "sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-member-expression-to-functions": "^7.27.1",
         "@babel/helper-optimise-call-expression": "^7.27.1",
@@ -324,7 +321,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
       "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
-      "dev": true,
       "dependencies": {
         "@babel/traverse": "^7.27.1",
         "@babel/types": "^7.27.1"
@@ -647,7 +643,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
       "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -756,7 +751,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
       "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -787,7 +781,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
       "integrity": "sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -866,7 +859,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.27.1.tgz",
       "integrity": "sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.27.1",
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -898,7 +890,6 @@
       "version": "7.27.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.27.7.tgz",
       "integrity": "sha512-CuLkokN1PEZ0Fsjtq+001aog/C2drDK9nTfK/NRK0n6rBin6cBrvM+zfQjDE+UllhR6/J4a6w8Xq9i4yi3mQrw==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
         "@babel/helper-compilation-targets": "^7.27.2",
@@ -1167,7 +1158,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz",
       "integrity": "sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-module-transforms": "^7.27.1",
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1248,7 +1238,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz",
       "integrity": "sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -1328,7 +1317,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.27.1.tgz",
       "integrity": "sha512-BQmKPPIuc8EkZgNKsv0X4bPmOoayeu4F1YCwx2/CfmDSXDbp7GnzlUH+/ul5VGfRg1AoFPsrIThlEBj2xb4CAg==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
@@ -1537,7 +1525,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
       "integrity": "sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -1583,7 +1570,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
       "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -1613,7 +1599,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.27.1.tgz",
       "integrity": "sha512-Q5sT5+O4QUebHdbwKedFBEwRLb02zJ7r4A5Gg2hUoLuU3FjdMcyqcywqUrLCaDsFCxzokf7u9kuy7qz51YUuAg==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.1",
         "@babel/helper-create-class-features-plugin": "^7.27.1",
@@ -1663,7 +1648,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz",
       "integrity": "sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.27.1",
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1788,6 +1772,25 @@
         "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
       }
     },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
+      "integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.27.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
@@ -1861,6 +1864,18 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.7.0",
@@ -1980,6 +1995,45 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@gorhom/bottom-sheet": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@gorhom/bottom-sheet/-/bottom-sheet-5.2.4.tgz",
+      "integrity": "sha512-fItmuq5DUWXE4CNUrarboXxfS4hyVEi0uRhoTTyRrGHeL6Hib+bWaJkXMSou744KLAvgLLuwOWUry/wuTQTO6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@gorhom/portal": "1.0.14",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-native": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-gesture-handler": ">=2.16.1",
+        "react-native-reanimated": ">=3.16.0 || >=4.0.0-"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@gorhom/portal": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@gorhom/portal/-/portal-1.0.14.tgz",
+      "integrity": "sha512-MXyL4xvCjmgaORr/rtryDNFy3kU4qUbKlwtQqqsygd0xX3mhKjOLn6mQK8wfu0RkoE0pBE0nAasRoHua+/QZ7A==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@hapi/hoek": {
@@ -3605,6 +3659,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "license": "MIT"
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -3695,7 +3755,7 @@
       "version": "0.70.19",
       "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.70.19.tgz",
       "integrity": "sha512-c6WbyCgWTBgKKMESj/8b4w+zWcZSsCforson7UdXtXMecG3MxCinYi6ihhrHVPyUrVzORsvEzK8zg32z4pK6Sg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -7040,6 +7100,21 @@
       "dependencies": {
         "hermes-estree": "0.28.1"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -10447,6 +10522,21 @@
         }
       }
     },
+    "node_modules/react-native-gesture-handler": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
+      "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@egjs/hammerjs": "^2.0.17",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-image-crop-picker": {
       "version": "0.50.1",
       "resolved": "https://registry.npmjs.org/react-native-image-crop-picker/-/react-native-image-crop-picker-0.50.1.tgz",
@@ -10481,6 +10571,41 @@
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/react-native-pager-view/-/react-native-pager-view-6.9.1.tgz",
       "integrity": "sha512-uUT0MMMbNtoSbxe9pRvdJJKEi9snjuJ3fXlZhG8F2vVMOBJVt/AFtqMPUHu9yMflmqOr08PewKzj9EPl/Yj+Gw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-reanimated": {
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.19.1.tgz",
+      "integrity": "sha512-ILL0FSNzSVIg6WuawrsMBvNxk2yJFiTUcahimXDAeNiE/09eagVUlHhYWXAAmH0umvAOafBaGjO7YfBhUrf5ZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
+        "@babel/plugin-transform-class-properties": "^7.0.0-0",
+        "@babel/plugin-transform-classes": "^7.0.0-0",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
+        "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
+        "@babel/plugin-transform-template-literals": "^7.0.0-0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
+        "@babel/preset-typescript": "^7.16.7",
+        "convert-source-map": "^2.0.0",
+        "invariant": "^2.2.4",
+        "react-native-is-edge-to-edge": "1.1.7"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-reanimated/node_modules/react-native-is-edge-to-edge": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.7.tgz",
+      "integrity": "sha512-EH6i7E8epJGIcu7KpfXYXiV2JFIYITtq+rVS8uEb+92naMRBdxhTuS8Wn2Q7j9sqyO0B+Xbaaf9VdipIAmGW4w==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*",
@@ -10710,14 +10835,12 @@
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
-      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
-      "dev": true
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A=="
     },
     "node_modules/regenerate-unicode-properties": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.0.tgz",
       "integrity": "sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==",
-      "dev": true,
       "dependencies": {
         "regenerate": "^1.4.2"
       },
@@ -10754,7 +10877,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.2.0.tgz",
       "integrity": "sha512-H66BPQMrv+V16t8xtmq+UC0CBpiTBA60V8ibS1QVReIp8T1z8hwFxqcGzm9K6lgsN7sB5edVH8a+ze6Fqm4weA==",
-      "dev": true,
       "dependencies": {
         "regenerate": "^1.4.2",
         "regenerate-unicode-properties": "^10.2.0",
@@ -10770,14 +10892,12 @@
     "node_modules/regjsgen": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
-      "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
-      "dev": true
+      "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q=="
     },
     "node_modules/regjsparser": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.12.0.tgz",
       "integrity": "sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==",
-      "dev": true,
       "dependencies": {
         "jsesc": "~3.0.2"
       },
@@ -10789,7 +10909,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
       "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
-      "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -12028,7 +12147,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
       "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -12037,7 +12155,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
       "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
-      "dev": true,
       "dependencies": {
         "unicode-canonical-property-names-ecmascript": "^2.0.0",
         "unicode-property-aliases-ecmascript": "^2.0.0"
@@ -12050,7 +12167,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.0.tgz",
       "integrity": "sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -12059,7 +12175,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
       "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@gorhom/bottom-sheet": "^5.2.4",
     "@react-native-community/blur": "^4.4.1",
     "@react-native/new-app-screen": "0.80.0",
     "@react-navigation/bottom-tabs": "^7.4.2",
@@ -18,9 +19,11 @@
     "@react-navigation/native-stack": "^7.3.25",
     "react": "19.1.0",
     "react-native": "0.80.0",
+    "react-native-gesture-handler": "^2.28.0",
     "react-native-image-crop-picker": "^0.50.1",
     "react-native-linear-gradient": "^2.8.3",
     "react-native-pager-view": "^6.9.1",
+    "react-native-reanimated": "^3.19.1",
     "react-native-safe-area-context": "^5.5.2",
     "react-native-screens": "^4.13.1",
     "react-native-svg": "^15.12.1",

--- a/src/components/OppuTagBadge/ClickableOppuTagBadge.tsx
+++ b/src/components/OppuTagBadge/ClickableOppuTagBadge.tsx
@@ -1,9 +1,9 @@
 import { Pressable, View } from 'react-native';
-import { Tag } from '../../types/tag';
+import { UITag } from '../../types/tag';
 import OppuTagBadge from '.';
 
 interface ClickableOppuTagBadgeProps {
-  tag: Tag;
+  tag: UITag;
   selected: boolean;
   onPress: () => void;
 }

--- a/src/components/OppuTagBadge/index.tsx
+++ b/src/components/OppuTagBadge/index.tsx
@@ -1,11 +1,11 @@
 import { View } from 'react-native';
-import { Tag } from '../../types/tag';
+import { UITag } from '../../types/tag';
 import styles from './style';
 import { Text } from '../Text';
 import colors from '../../theme/color';
 
 interface OppuTagBadgeProps {
-  tag: Tag;
+  tag: UITag;
   selected?: boolean;
 }
 
@@ -18,7 +18,7 @@ const OppuTagBadge: React.FC<OppuTagBadgeProps> = ({
       style={[
         styles.container,
         {
-          backgroundColor: selected ? tag.color + '80' : colors.grey4,
+          backgroundColor: selected ? tag.backgroundColor : 'transparent',
           borderColor: selected ? tag.color : colors.grey8,
         },
       ]}

--- a/src/screens/CreateOppuScreen/components/BaseButton/index.tsx
+++ b/src/screens/CreateOppuScreen/components/BaseButton/index.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { View, Pressable, ViewStyle, StyleProp } from 'react-native';
+import { Text } from '../../../../components/Text';
+import styles from './styles';
+import colors from '../../../../theme/color';
+import Feather from 'react-native-vector-icons/Feather';
+
+type BaseButtonProps = {
+  title: string;
+  onPress: () => void;
+  icon?: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
+};
+
+function BaseButton({ title, onPress, icon, style }: BaseButtonProps) {
+  return (
+    <Pressable style={[styles.container, style]} onPress={onPress}>
+      {icon && <View style={styles.iconWrapper}>{icon}</View>}
+      <Text variant="body" weight="semiBold" color={colors.white}>
+        {title}
+      </Text>
+    </Pressable>
+  );
+}
+
+export function AddPerfumeButton({
+  onPress,
+  style,
+}: {
+  onPress: () => void;
+  style?: StyleProp<ViewStyle>;
+}) {
+  return (
+    <BaseButton
+      title="향수 추가"
+      onPress={onPress}
+      icon={<Feather name="plus" />}
+      style={style} // 스타일 전달
+    />
+  );
+}
+
+export function CompleteButton({
+  onPress,
+  style,
+}: {
+  onPress: () => void;
+  style?: StyleProp<ViewStyle>;
+}) {
+  return <BaseButton title="완료" onPress={onPress} style={style} />;
+}

--- a/src/screens/CreateOppuScreen/components/BaseButton/index.tsx
+++ b/src/screens/CreateOppuScreen/components/BaseButton/index.tsx
@@ -73,7 +73,7 @@ export function CompleteButton({
 }) {
   return (
     <BaseButton
-      title="설정 완료"
+      title="태그 설정 완료"
       onPress={onPress}
       style={style}
       disabled={disabled}

--- a/src/screens/CreateOppuScreen/components/BaseButton/index.tsx
+++ b/src/screens/CreateOppuScreen/components/BaseButton/index.tsx
@@ -10,13 +10,32 @@ type BaseButtonProps = {
   onPress: () => void;
   icon?: React.ReactNode;
   style?: StyleProp<ViewStyle>;
+  disabled?: boolean;
 };
 
-function BaseButton({ title, onPress, icon, style }: BaseButtonProps) {
+function BaseButton({
+  title,
+  onPress,
+  icon,
+  style,
+  disabled,
+}: BaseButtonProps) {
   return (
-    <Pressable style={[styles.container, style]} onPress={onPress}>
+    <Pressable
+      style={[
+        styles.container,
+        style,
+        disabled && { backgroundColor: colors.grey12 },
+      ]}
+      onPress={onPress}
+      disabled={disabled}
+    >
       {icon && <View style={styles.iconWrapper}>{icon}</View>}
-      <Text variant="body" weight="semiBold" color={colors.white}>
+      <Text
+        variant="body"
+        weight="semiBold"
+        color={disabled ? colors.black : colors.white}
+      >
         {title}
       </Text>
     </Pressable>
@@ -26,16 +45,19 @@ function BaseButton({ title, onPress, icon, style }: BaseButtonProps) {
 export function AddPerfumeButton({
   onPress,
   style,
+  disabled = false,
 }: {
   onPress: () => void;
   style?: StyleProp<ViewStyle>;
+  disabled?: boolean;
 }) {
   return (
     <BaseButton
       title="향수 추가"
       onPress={onPress}
       icon={<Feather name="plus" />}
-      style={style} // 스타일 전달
+      style={style}
+      disabled={disabled}
     />
   );
 }
@@ -43,9 +65,18 @@ export function AddPerfumeButton({
 export function CompleteButton({
   onPress,
   style,
+  disabled,
 }: {
   onPress: () => void;
   style?: StyleProp<ViewStyle>;
+  disabled?: boolean;
 }) {
-  return <BaseButton title="완료" onPress={onPress} style={style} />;
+  return (
+    <BaseButton
+      title="설정 완료"
+      onPress={onPress}
+      style={style}
+      disabled={disabled}
+    />
+  );
 }

--- a/src/screens/CreateOppuScreen/components/BaseButton/styles.ts
+++ b/src/screens/CreateOppuScreen/components/BaseButton/styles.ts
@@ -1,0 +1,19 @@
+import { StyleSheet } from 'react-native';
+import colors from '../../../../theme/color';
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 8,
+    borderRadius: 16,
+    padding: 16,
+    backgroundColor: colors.black,
+    marginTop: 8,
+  },
+  content: {},
+  iconWrapper: {},
+});
+
+export default styles;

--- a/src/screens/CreateOppuScreen/components/TagList/index.tsx
+++ b/src/screens/CreateOppuScreen/components/TagList/index.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { View, Pressable, FlatList } from 'react-native';
-import { Tag } from '../../../../types/tag';
+import { UITag } from '../../../../types/tag';
 import styles from './styles';
 import { Text } from '../../../../components/Text';
 import Feather from 'react-native-vector-icons/Feather';
 
 type TagListProps = {
-  tags: Tag[];
+  tags: UITag[];
   selectedTagId: string | null;
   onSelectTag: (id: string) => void;
   onDeleteTagLabel: (id: string) => void;
@@ -18,18 +18,28 @@ export default function TagList({
   onSelectTag,
   onDeleteTagLabel,
 }: TagListProps) {
-  const renderItem = ({ item: tag }: { item: Tag }) => {
+  const renderItem = ({ item: tag }: { item: UITag }) => {
     const isSelected = selectedTagId === tag.id;
     const hasLabel = !!tag.label;
 
     return (
       <Pressable
-        style={[styles.tagItem, isSelected && { borderColor: tag.color }]}
+        style={[
+          styles.tagItem,
+          {
+            borderColor: isSelected ? tag.color : 'transparent',
+            backgroundColor: tag.backgroundColor,
+            width: hasLabel ? undefined : 32,
+            height: hasLabel ? undefined : 32,
+          },
+        ]}
         onPress={() => onSelectTag(tag.id)}
       >
         {hasLabel && (
           <View style={styles.labelContainer}>
-            <Text>{tag.label}</Text>
+            <Text variant="caption1" weight="semiBold" color={tag.color}>
+              {tag.label}
+            </Text>
             <Pressable
               style={styles.deleteButton}
               onPress={e => {
@@ -37,7 +47,7 @@ export default function TagList({
                 onDeleteTagLabel(tag.id);
               }}
             >
-              <Feather name="x" />
+              <Feather name="x" color={tag.color} />
             </Pressable>
           </View>
         )}

--- a/src/screens/CreateOppuScreen/components/TagList/index.tsx
+++ b/src/screens/CreateOppuScreen/components/TagList/index.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { View, Pressable, FlatList } from 'react-native';
+import { Tag } from '../../../../types/tag';
+import styles from './styles';
+import { Text } from '../../../../components/Text';
+import Feather from 'react-native-vector-icons/Feather';
+
+type TagListProps = {
+  tags: Tag[];
+  selectedTagId: string | null;
+  onSelectTag: (id: string) => void;
+  onDeleteTagLabel: (id: string) => void;
+};
+
+export default function TagList({
+  tags,
+  selectedTagId,
+  onSelectTag,
+  onDeleteTagLabel,
+}: TagListProps) {
+  const renderItem = ({ item: tag }: { item: Tag }) => {
+    const isSelected = selectedTagId === tag.id;
+    const hasLabel = !!tag.label;
+
+    return (
+      <Pressable
+        style={[styles.tagItem, isSelected && { borderColor: tag.color }]}
+        onPress={() => onSelectTag(tag.id)}
+      >
+        {hasLabel && (
+          <View style={styles.labelContainer}>
+            <Text>{tag.label}</Text>
+            <Pressable
+              style={styles.deleteButton}
+              onPress={e => {
+                e.stopPropagation();
+                onDeleteTagLabel(tag.id);
+              }}
+            >
+              <Feather name="x" />
+            </Pressable>
+          </View>
+        )}
+      </Pressable>
+    );
+  };
+
+  return (
+    <FlatList
+      horizontal
+      data={tags}
+      keyExtractor={item => item.id}
+      renderItem={renderItem}
+      showsHorizontalScrollIndicator={false}
+      ItemSeparatorComponent={() => <View style={{ width: 8 }} />}
+      contentContainerStyle={styles.container}
+    />
+  );
+}

--- a/src/screens/CreateOppuScreen/components/TagList/styles.ts
+++ b/src/screens/CreateOppuScreen/components/TagList/styles.ts
@@ -1,0 +1,22 @@
+import { StyleSheet } from 'react-native';
+
+const styles = StyleSheet.create({
+  container: {},
+  tagItem: {
+    borderRadius: 22,
+    paddingHorizontal: 9,
+    paddingVertical: 8,
+    borderWidth: 1,
+    borderColor: 'transparent',
+  },
+  labelContainer: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  deleteButton: {
+    marginLeft: 8,
+  },
+});
+
+export default styles;

--- a/src/screens/CreateOppuScreen/components/TagList/styles.ts
+++ b/src/screens/CreateOppuScreen/components/TagList/styles.ts
@@ -7,7 +7,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 9,
     paddingVertical: 8,
     borderWidth: 1,
-    borderColor: 'transparent',
   },
   labelContainer: {
     flexDirection: 'row',
@@ -15,7 +14,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   deleteButton: {
-    marginLeft: 8,
+    marginLeft: 4,
   },
 });
 

--- a/src/screens/CreateOppuScreen/components/TagSetting/index.tsx
+++ b/src/screens/CreateOppuScreen/components/TagSetting/index.tsx
@@ -9,7 +9,7 @@ import { BottomSheetTextInput } from '@gorhom/bottom-sheet';
 
 type TagSettingProps = {
   tags: UITag[];
-  onComplete: (newTags: UITag[]) => void;
+  onComplete: (newTags: UITag[]) => void; // TODO: 서버 연결 부분
 };
 
 function TagSetting({ tags, onComplete }: TagSettingProps) {
@@ -25,6 +25,12 @@ function TagSetting({ tags, onComplete }: TagSettingProps) {
     setDraftLabel(text);
     if (isEditing) return;
     setIsEditing(true);
+  };
+
+  const resetEditingState = () => {
+    setIsEditing(false);
+    setSelectedTagId(null);
+    setDraftLabel('');
   };
 
   const handleSelectTag = (id: string) => {
@@ -46,9 +52,7 @@ function TagSetting({ tags, onComplete }: TagSettingProps) {
       ),
     );
 
-    setIsEditing(false);
-    setSelectedTagId(null);
-    setDraftLabel('');
+    resetEditingState();
   };
 
   const handleDelete = (id: string) => {
@@ -65,11 +69,7 @@ function TagSetting({ tags, onComplete }: TagSettingProps) {
       prev.map(tag => (tag.id === id ? { ...tag, label: null } : tag)),
     );
 
-    if (selectedTagId == id) {
-      setIsEditing(false);
-      setSelectedTagId(null);
-      setDraftLabel('');
-    }
+    if (selectedTagId == id) resetEditingState();
   };
 
   let placeholderText = '태그 색상을 먼저 선택해주세요!';

--- a/src/screens/CreateOppuScreen/components/TagSetting/index.tsx
+++ b/src/screens/CreateOppuScreen/components/TagSetting/index.tsx
@@ -1,5 +1,5 @@
 import { Pressable, TextInput, View } from 'react-native';
-import { Tag } from '../../../../types/tag';
+import { UITag } from '../../../../types/tag';
 import { useState } from 'react';
 import styles from './styles';
 import { Text } from '../../../../components/Text';
@@ -8,12 +8,12 @@ import TagList from '../TagList';
 import { BottomSheetTextInput } from '@gorhom/bottom-sheet';
 
 type TagSettingProps = {
-  tags: Tag[];
-  onComplete: (newTags: Tag[]) => void;
+  tags: UITag[];
+  onComplete: (newTags: UITag[]) => void;
 };
 
 function TagSetting({ tags, onComplete }: TagSettingProps) {
-  const [currentTags, setCurrentTags] = useState<Tag[]>([...tags]);
+  const [currentTags, setCurrentTags] = useState<UITag[]>([...tags]);
   const [selectedTagId, setSelectedTagId] = useState<string | null>(null);
 
   const selectedTag = currentTags.find(tag => tag.id === selectedTagId) || null;

--- a/src/screens/CreateOppuScreen/components/TagSetting/index.tsx
+++ b/src/screens/CreateOppuScreen/components/TagSetting/index.tsx
@@ -1,0 +1,96 @@
+import { Pressable, TextInput, View } from 'react-native';
+import { Tag } from '../../../../types/tag';
+import { useState } from 'react';
+import styles from './styles';
+import { Text } from '../../../../components/Text';
+import { CompleteButton } from '../BaseButton';
+import TagList from '../TagList';
+import { BottomSheetTextInput } from '@gorhom/bottom-sheet';
+
+type TagSettingProps = {
+  tags: Tag[];
+  onComplete: (newTags: Tag[]) => void;
+};
+
+function TagSetting({ tags, onComplete }: TagSettingProps) {
+  const [currentTags, setCurrentTags] = useState<Tag[]>([...tags]);
+  const [selectedTagId, setSelectedTagId] = useState<string | null>(null);
+
+  const selectedTag = currentTags.find(tag => tag.id === selectedTagId) || null;
+
+  const handleChangeLabel = (text: string) => {
+    if (!selectedTagId) return;
+    setCurrentTags(prev =>
+      prev.map(tag =>
+        tag.id === selectedTagId ? { ...tag, label: text } : tag,
+      ),
+    );
+  };
+
+  let placeholderText = '태그 색상을 먼저 선택해주세요!';
+  if (selectedTag) {
+    placeholderText = selectedTag.label ? '' : '태그 이름을 설정해주세요!';
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text variant="bodyCompact" weight="semiBold">
+          태그 설정
+        </Text>
+      </View>
+
+      <View style={styles.content}>
+        <View>
+          <View style={[styles.wrapper, styles.nameWrapper]}>
+            <TagLabel label="태그 이름" />
+
+            <Spacer />
+            <BottomSheetTextInput
+              value={selectedTag?.label || ''}
+              placeholder={placeholderText}
+              editable={!!selectedTag}
+              onChangeText={handleChangeLabel}
+              style={[styles.nameInput]}
+            />
+          </View>
+
+          <Spacer />
+
+          <View style={[styles.wrapper, styles.colorWrapper]}>
+            <TagLabel label="태그 색상" />
+            <Spacer />
+            <TagList
+              tags={currentTags}
+              selectedTagId={selectedTagId}
+              onSelectTag={id => setSelectedTagId(id)}
+              onDeleteTagLabel={id => {
+                // TODO : 태그 삭제 관련
+              }}
+            />
+          </View>
+        </View>
+
+        <CompleteButton
+          onPress={() => {
+            onComplete(currentTags);
+          }}
+        />
+      </View>
+    </View>
+  );
+}
+
+function TagLabel({ label }: { label: string }) {
+  return (
+    <Text variant="bodyCompact" weight="semiBold">
+      {label}
+    </Text>
+  );
+}
+
+function Spacer({ gap = 20 }: { gap?: number }) {
+  return <View style={{ height: gap }} />;
+}
+
+export default TagSetting;

--- a/src/screens/CreateOppuScreen/components/TagSetting/index.tsx
+++ b/src/screens/CreateOppuScreen/components/TagSetting/index.tsx
@@ -15,16 +15,61 @@ type TagSettingProps = {
 function TagSetting({ tags, onComplete }: TagSettingProps) {
   const [currentTags, setCurrentTags] = useState<UITag[]>([...tags]);
   const [selectedTagId, setSelectedTagId] = useState<string | null>(null);
-
   const selectedTag = currentTags.find(tag => tag.id === selectedTagId) || null;
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [draftLabel, setDraftLabel] = useState('');
 
   const handleChangeLabel = (text: string) => {
     if (!selectedTagId) return;
+    setDraftLabel(text);
+    if (isEditing) return;
+    setIsEditing(true);
+  };
+
+  const handleSelectTag = (id: string) => {
+    if (isEditing) {
+      // TODO: 경고창
+      return;
+    }
+    const tag = currentTags.find(t => t.id === id);
+    setSelectedTagId(id);
+    setDraftLabel(tag?.label || '');
+  };
+
+  const handleComplete = () => {
+    if (!selectedTagId) return;
+
     setCurrentTags(prev =>
       prev.map(tag =>
-        tag.id === selectedTagId ? { ...tag, label: text } : tag,
+        tag.id === selectedTagId ? { ...tag, label: draftLabel } : tag,
       ),
     );
+
+    setIsEditing(false);
+    setSelectedTagId(null);
+    setDraftLabel('');
+  };
+
+  const handleDelete = (id: string) => {
+    // 라벨 있는 태그가 1개만 남은 경우 -> 삭제 불가
+    const labeledCount = currentTags.filter(
+      tag => tag.label && tag.label.trim() !== '',
+    ).length;
+    if (labeledCount <= 1) {
+      // TODO: 경고창
+      return;
+    }
+    // TODO: 삭제 시 경고창 띄우고,
+    setCurrentTags(prev =>
+      prev.map(tag => (tag.id === id ? { ...tag, label: null } : tag)),
+    );
+
+    if (selectedTagId == id) {
+      setIsEditing(false);
+      setSelectedTagId(null);
+      setDraftLabel('');
+    }
   };
 
   let placeholderText = '태그 색상을 먼저 선택해주세요!';
@@ -47,7 +92,7 @@ function TagSetting({ tags, onComplete }: TagSettingProps) {
 
             <Spacer />
             <BottomSheetTextInput
-              value={selectedTag?.label || ''}
+              value={draftLabel || ''}
               placeholder={placeholderText}
               editable={!!selectedTag}
               onChangeText={handleChangeLabel}
@@ -63,19 +108,18 @@ function TagSetting({ tags, onComplete }: TagSettingProps) {
             <TagList
               tags={currentTags}
               selectedTagId={selectedTagId}
-              onSelectTag={id => setSelectedTagId(id)}
-              onDeleteTagLabel={id => {
-                // TODO : 태그 삭제 관련
-              }}
+              onSelectTag={id => handleSelectTag(id)}
+              onDeleteTagLabel={handleDelete}
             />
           </View>
         </View>
 
         <CompleteButton
           onPress={() => {
-            onComplete(currentTags);
+            handleComplete();
+            // onComplete(currentTags);
           }}
-          disabled={true}
+          disabled={!isEditing || draftLabel.trim() === ''}
         />
       </View>
     </View>

--- a/src/screens/CreateOppuScreen/components/TagSetting/index.tsx
+++ b/src/screens/CreateOppuScreen/components/TagSetting/index.tsx
@@ -75,6 +75,7 @@ function TagSetting({ tags, onComplete }: TagSettingProps) {
           onPress={() => {
             onComplete(currentTags);
           }}
+          disabled={true}
         />
       </View>
     </View>

--- a/src/screens/CreateOppuScreen/components/TagSetting/styles.ts
+++ b/src/screens/CreateOppuScreen/components/TagSetting/styles.ts
@@ -1,0 +1,38 @@
+import { StyleSheet } from 'react-native';
+import colors from '../../../../theme/color';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingVertical: 16,
+  },
+  content: {
+    flex: 1,
+    padding: 20,
+    justifyContent: 'space-between',
+  },
+  wrapper: {
+    padding: 20,
+    backgroundColor: colors.white32,
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.8)',
+    borderRadius: 20,
+  },
+  nameWrapper: {},
+  nameInput: {
+    alignSelf: 'stretch',
+    borderColor: colors.grey31,
+    fontFamily: 'Pretendard-Regular',
+    fontSize: 16,
+    lineHeight: 24,
+    letterSpacing: -1.0,
+    color: colors.grey100,
+  },
+  colorWrapper: {},
+});
+
+export default styles;

--- a/src/screens/CreateOppuScreen/index.tsx
+++ b/src/screens/CreateOppuScreen/index.tsx
@@ -88,8 +88,8 @@ const CreateOppuScreen: React.FC = () => {
       <BottomSheetBackdrop
         {...props}
         pressBehavior="close"
-        appearsOnIndex={0} // 이거 추가
-        disappearsOnIndex={-1} // 이거 추가
+        appearsOnIndex={0}
+        disappearsOnIndex={-1}
       />
     ),
     [],

--- a/src/screens/CreateOppuScreen/index.tsx
+++ b/src/screens/CreateOppuScreen/index.tsx
@@ -1,31 +1,33 @@
-import React, { useState } from 'react';
+import React, { useMemo, useRef, useState, useCallback } from 'react';
 import {
   View,
   ScrollView,
   SafeAreaView,
-  Pressable,
   FlatList,
   TextInput,
-  KeyboardAvoidingView,
-  Platform,
 } from 'react-native';
 import styles from './styles';
 import { Text } from '../../components/Text';
-import SubmitButton from '../../components/Buttons/SubmitButton';
 import { TitleHeaderText, SubtitleHeaderText } from './components/HeaderText';
 import colors from '../../theme/color';
-import PlusIcon from '../../assets/svgs/plus.svg';
 import Toggle from '../../components/Toggle';
 import PerfumeSpray from './components/PerfumeSpray';
 import { PerfumeInfo } from '../../types/perfume';
 import PhotoSlot from './components/PhotoSlot';
 import IconButton from './components/IconButton';
 import ClickableOppuTagBadge from '../../components/OppuTagBadge/ClickableOppuTagBadge';
-import TextField from '../../components/TextField';
 import CustomStackHeader from '../../components/CustomStackHeader';
 import { useNavigation } from '@react-navigation/native';
 import { RootNavProp } from '../../types/navigationProps';
 import Divider from '../../components/Divider';
+import {
+  BottomSheetModal,
+  BottomSheetModalProvider,
+  BottomSheetBackdrop,
+  BottomSheetBackdropProps,
+} from '@gorhom/bottom-sheet';
+import { AddPerfumeButton } from './components/BaseButton';
+import TagSetting from './components/TagSetting';
 
 const dummyPerfume = {
   id: 1,
@@ -64,139 +66,189 @@ const CreateOppuScreen: React.FC = () => {
   const [text, setText] = useState('');
   const navigation = useNavigation<RootNavProp>();
 
-  return (
-    <SafeAreaView style={styles.container}>
-      <CustomStackHeader
-        title="오뿌 작성"
-        onPress={() => {}}
-        onBackPress={() => {
-          navigation.goBack();
-        }}
+  const bottomSheetRef = useRef<BottomSheetModal>(null);
+  const snapPoints = useMemo(() => ['80%'], []);
+
+  const handlePresentModalPress = useCallback(() => {
+    bottomSheetRef.current?.present();
+  }, []);
+
+  const handleDismissModalPress = useCallback(() => {
+    bottomSheetRef.current?.close();
+  }, []);
+
+  const renderBackdrop = useCallback(
+    (props: BottomSheetBackdropProps) => (
+      <BottomSheetBackdrop
+        {...props}
+        pressBehavior="close"
+        appearsOnIndex={0} // 이거 추가
+        disappearsOnIndex={-1} // 이거 추가
       />
-      <ScrollView style={styles.content}>
-        {/* 향수 설정 파트 */}
-        <View style={styles.perfumeWrapper}>
-          <TitleHeaderText
-            title="향수"
-            description="오늘 뿌린 향수를 추가하고 횟수를 선택해주세요"
-          />
+    ),
+    [],
+  );
+
+  return (
+    <BottomSheetModalProvider>
+      <SafeAreaView style={styles.container}>
+        <CustomStackHeader
+          title="오뿌 작성"
+          onPress={() => {}}
+          onBackPress={() => {
+            navigation.goBack();
+          }}
+        />
+
+        <ScrollView style={styles.content}>
+          {/* 향수 설정 파트 */}
+          <View style={styles.perfumeWrapper}>
+            <TitleHeaderText
+              title="향수"
+              description="오늘 뿌린 향수를 추가하고 횟수를 선택해주세요"
+            />
+
+            <Spacer />
+
+            <FlatList
+              data={perfumes}
+              horizontal
+              keyExtractor={item => item.id.toString()}
+              renderItem={({ item }) => (
+                <PerfumeSpray
+                  perfume={item.perfume}
+                  count={item.spray}
+                  onDelete={() => {}}
+                  onDecrement={() => {}}
+                  onIncrement={() => {}}
+                />
+              )}
+              ItemSeparatorComponent={() => <View style={{ width: 12 }} />}
+              contentContainerStyle={{ padding: 8 }}
+              showsHorizontalScrollIndicator={false}
+            />
+
+            {perfumes.length < 3 && <AddPerfumeButton onPress={() => {}} />}
+          </View>
+
+          {/* TODO: 작성 날짜 설정 */}
+
+          <View style={styles.tagWrapper}>
+            <View style={styles.tagHeader}>
+              <TitleHeaderText
+                title="태그"
+                description="향수를 잘 표현하는 키워드를 선택해주세요"
+              />
+              <IconButton
+                icon="plus"
+                onPress={handlePresentModalPress}
+                style={styles.tagIcon}
+              />
+            </View>
+
+            <FlatList
+              data={dummyTags}
+              horizontal
+              keyExtractor={item => item.id}
+              ItemSeparatorComponent={() => <View style={{ width: 8 }} />}
+              renderItem={({ item }) => (
+                <ClickableOppuTagBadge
+                  tag={item}
+                  selected={false}
+                  onPress={() => {}}
+                />
+              )}
+            />
+          </View>
 
           <Spacer />
 
-          <FlatList
-            data={perfumes}
-            horizontal
-            keyExtractor={item => item.id.toString()}
-            renderItem={({ item }) => (
-              <PerfumeSpray
-                perfume={item.perfume}
-                count={item.spray}
-                onDelete={() => {}}
-                onDecrement={() => {}}
-                onIncrement={() => {}}
-              />
-            )}
-            ItemSeparatorComponent={() => <View style={{ width: 12 }} />}
-            contentContainerStyle={{ padding: 8 }}
-            showsHorizontalScrollIndicator={false}
-          />
-
-          {perfumes.length < 3 && (
-            <Pressable style={styles.addPerfumeButton} onPress={() => {}}>
-              <PlusIcon />
-              <Text variant="body" weight="semiBold" color={colors.white}>
-                향수 추가
-              </Text>
-            </Pressable>
-          )}
-        </View>
-
-        {/* TODO: 작성 날짜 설정 */}
-
-        <View style={styles.tagWrapper}>
-          <View style={styles.tagHeader}>
-            <TitleHeaderText
-              title="태그"
-              description="향수를 잘 표현하는 키워드를 선택해주세요"
-            />
-            <IconButton
-              icon="plus"
-              onPress={() => {}}
-              style={{ backgroundColor: colors.grey12 }}
-            />
-          </View>
-
-          <FlatList
-            data={dummyTags}
-            horizontal
-            keyExtractor={item => item.id}
-            ItemSeparatorComponent={() => <View style={{ width: 8 }} />}
-            renderItem={({ item }) => (
-              <ClickableOppuTagBadge
-                tag={item}
-                selected={false}
-                onPress={() => {}}
-              />
-            )}
-          />
-        </View>
-
-        <Spacer />
-
-        <View style={styles.optionalWrapper}>
-          <SubtitleHeaderText
-            title="사진"
-            description="향수와 함께한 오늘의 순간을 사진으로 남겨보세요"
-          />
-
-          <View style={styles.photoWrapper}>
-            {[0, 1, 2].map(i => (
-              <PhotoSlot
-                key={i}
-                image={photos[i]}
-                isAddButton={i === photos.length}
-                onPick={() => {
-                  // 갤러리 접근
-                }}
-              />
-            ))}
-          </View>
-        </View>
-
-        <Spacer />
-
-        <View style={styles.optionalWrapper}>
-          <SubtitleHeaderText title="기록" />
-          <TextInput
-            style={styles.textInput}
-            value={text}
-            onChangeText={setText}
-            placeholder={'향수와 함께한 오늘을 기록하세요'}
-            placeholderTextColor={colors.grey31}
-            multiline={true}
-            numberOfLines={5}
-          />
-        </View>
-
-        <Spacer />
-
-        <View style={styles.optionalWrapper}>
-          <View style={styles.feedbackHeader}>
+          <View style={styles.optionalWrapper}>
             <SubtitleHeaderText
-              title="호드백 받은 날"
-              description="오늘 향수를 뿌리고 반응이 좋았나요?"
+              title="사진"
+              description="향수와 함께한 오늘의 순간을 사진으로 남겨보세요"
             />
-            <Toggle onToggle={() => {}} isOn={false} />
-          </View>
-          <Divider />
-          <Text variant="caption1" weight="regular" color={colors.grey54}>
-            호드백은 향수를 사용했을 때 주변에서 들은 긍정적인 피드백을 의미해요
-          </Text>
-        </View>
 
-        <View style={{ height: 78 }} />
-      </ScrollView>
-    </SafeAreaView>
+            <View style={styles.photoWrapper}>
+              {[0, 1, 2].map(i => (
+                <PhotoSlot
+                  key={i}
+                  image={photos[i]}
+                  isAddButton={i === photos.length}
+                  onPick={() => {
+                    // 갤러리 접근
+                  }}
+                />
+              ))}
+            </View>
+          </View>
+
+          <Spacer />
+
+          <View style={styles.optionalWrapper}>
+            <SubtitleHeaderText title="기록" />
+            <TextInput
+              style={styles.textInput}
+              value={text}
+              onChangeText={setText}
+              placeholder={'향수와 함께한 오늘을 기록하세요'}
+              placeholderTextColor={colors.grey31}
+              multiline={true}
+              numberOfLines={5}
+            />
+          </View>
+
+          <Spacer />
+
+          <View style={styles.optionalWrapper}>
+            <View style={styles.feedbackHeader}>
+              <SubtitleHeaderText
+                title="호드백 받은 날"
+                description="오늘 향수를 뿌리고 반응이 좋았나요?"
+              />
+              <Toggle onToggle={() => {}} isOn={false} />
+            </View>
+            <Divider />
+            <Text variant="caption1" weight="regular" color={colors.grey54}>
+              호드백은 향수를 사용했을 때 주변에서 들은 긍정적인 피드백을
+              의미해요
+            </Text>
+          </View>
+
+          <View style={{ height: 78 }} />
+        </ScrollView>
+
+        <BottomSheetModal
+          ref={bottomSheetRef}
+          snapPoints={snapPoints}
+          onChange={index => {
+            console.log('BottomSheet 상태 변화:', index);
+            // index === -1 -> 닫힘
+            // index >= 0 -> 열림
+          }}
+          index={0}
+          backgroundStyle={{
+            backgroundColor: '#F6F6F6',
+          }}
+          handleStyle={{
+            backgroundColor: '#F6F6F6',
+            borderTopLeftRadius: 16,
+            borderTopRightRadius: 16,
+          }}
+          backdropComponent={renderBackdrop}
+          keyboardBehavior="extend"
+          enableDynamicSizing={false}
+        >
+          <TagSetting
+            tags={dummyTags}
+            onComplete={newTags => {
+              console.log('변경된 태그:', newTags);
+              handleDismissModalPress();
+            }}
+          />
+        </BottomSheetModal>
+      </SafeAreaView>
+    </BottomSheetModalProvider>
   );
 };
 

--- a/src/screens/CreateOppuScreen/index.tsx
+++ b/src/screens/CreateOppuScreen/index.tsx
@@ -28,6 +28,7 @@ import {
 } from '@gorhom/bottom-sheet';
 import { AddPerfumeButton } from './components/BaseButton';
 import TagSetting from './components/TagSetting';
+import { Tag, mapTags } from '../../types/tag';
 
 const dummyPerfume = {
   id: 1,
@@ -54,10 +55,12 @@ const dummyPerfumes = [
 const dummyPic =
   'https://images.unsplash.com/photo-1756142188854-34b1e9a9e415?q=80&w=1364&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D';
 
-const dummyTags = [
-  { id: '1', label: '오뿌', color: '#FF6B6B' },
-  { id: '2', label: '잠뿌', color: '#4ECDC4' },
-  { id: '3', label: '뿌', color: '#FFD93D' },
+const dummyTags: Tag[] = [
+  { id: '1', label: '오뿌', color: '#AF52DE' },
+  { id: '2', label: '잠뿌', color: '#0059FF' },
+  { id: '3', label: '뿌', color: '#5856D6' },
+  { id: '4', color: '#73BB4B' },
+  { id: '5', color: '#FF47D1' },
 ];
 
 const CreateOppuScreen: React.FC = () => {
@@ -65,6 +68,9 @@ const CreateOppuScreen: React.FC = () => {
   const [photos, setPhotos] = useState<string[]>([dummyPic]);
   const [text, setText] = useState('');
   const navigation = useNavigation<RootNavProp>();
+
+  const uiTags = useMemo(() => mapTags(dummyTags), [dummyTags]);
+  const [selectedTagId, setSelectedTagId] = useState<string>(uiTags[0].id);
 
   const bottomSheetRef = useRef<BottomSheetModal>(null);
   const snapPoints = useMemo(() => ['80%'], []);
@@ -147,15 +153,15 @@ const CreateOppuScreen: React.FC = () => {
             </View>
 
             <FlatList
-              data={dummyTags}
+              data={uiTags.filter(tag => tag.label && tag.label.trim() !== '')}
               horizontal
               keyExtractor={item => item.id}
               ItemSeparatorComponent={() => <View style={{ width: 8 }} />}
               renderItem={({ item }) => (
                 <ClickableOppuTagBadge
                   tag={item}
-                  selected={false}
-                  onPress={() => {}}
+                  selected={selectedTagId == item.id}
+                  onPress={() => setSelectedTagId(item.id)}
                 />
               )}
             />
@@ -240,7 +246,7 @@ const CreateOppuScreen: React.FC = () => {
           enableDynamicSizing={false}
         >
           <TagSetting
-            tags={dummyTags}
+            tags={uiTags}
             onComplete={newTags => {
               console.log('변경된 태그:', newTags);
               handleDismissModalPress();

--- a/src/screens/CreateOppuScreen/styles.ts
+++ b/src/screens/CreateOppuScreen/styles.ts
@@ -21,16 +21,6 @@ const styles = StyleSheet.create({
   perfumeWrapper: {
     padding: 20,
   },
-  addPerfumeButton: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
-    gap: 8,
-    borderRadius: 16,
-    padding: 16,
-    backgroundColor: colors.black,
-    marginTop: 8,
-  },
   tagWrapper: {
     padding: 20,
     gap: 20,

--- a/src/screens/CreateOppuScreen/styles.ts
+++ b/src/screens/CreateOppuScreen/styles.ts
@@ -16,7 +16,6 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   content: {
-    flex: 1,
     gap: 20,
   },
   perfumeWrapper: {
@@ -39,6 +38,9 @@ const styles = StyleSheet.create({
   tagHeader: {
     flexDirection: 'row',
     justifyContent: 'space-between',
+  },
+  tagIcon: {
+    backgroundColor: colors.grey12,
   },
   optionalWrapper: {
     padding: 20,

--- a/src/types/tag.ts
+++ b/src/types/tag.ts
@@ -2,7 +2,7 @@ import { hexToRgba } from '../utils/\bcolorsUtils';
 
 export interface Tag {
   id: string;
-  label?: string;
+  label?: string | null;
   color: string;
 }
 

--- a/src/types/tag.ts
+++ b/src/types/tag.ts
@@ -1,5 +1,18 @@
+import { hexToRgba } from '../utils/\bcolorsUtils';
+
 export interface Tag {
   id: string;
-  label: string;
+  label?: string;
   color: string;
+}
+
+export interface UITag extends Tag {
+  backgroundColor: string;
+}
+
+export function mapTags(tags: Tag[]): UITag[] {
+  return tags.map(tag => ({
+    ...tag,
+    backgroundColor: hexToRgba(tag.color, 0.12),
+  }));
 }

--- a/src/utils/colorsUtils.ts
+++ b/src/utils/colorsUtils.ts
@@ -1,0 +1,6 @@
+export function hexToRgba(hex: string, alpha: number) {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}


### PR DESCRIPTION
### 🔘 관련 이슈

- close #30

## ✨ 작업 결과
<img width="300" height="958" alt="스크린샷 2025-09-05 오후 1 40 07" src="https://github.com/user-attachments/assets/43ed76af-22da-48e2-8a24-43f5802610aa" />



## 👩🏻‍💻 작업 내용

- BottomSheet 라이브러리 사용 : [링크](https://github.com/gorhom/react-native-bottom-sheet?utm_source=chatgpt.com)
- 태그 설정/편집 로직 구현 (약간의 내맘대로)
  - 편집 가능한 태그는 하나씩만
  - 태그 편집 후 -> 설정 완료 버튼 클릭하면 그때 확정 작업
  - 태그 최소 1개 유지 -> * 삭제 버튼으로 태그를 삭제하면 전체 태그 수가 1 이상이어야 함

## 👀 PR 포인트
- 바텀 시트 어렵다 엉엉
- 서버 통신용 Tag 이외에 UI 용으로 하나 만듬 (백그라운드 `opacity` 적용 이슈) 

## Next Feature

- #29
- 경고 모달창 연결하는 부분